### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Spiros Papadimitriou
 maintainer=Spiros Papadimitriou <spapadim@gmail.com>
 sentence=Driver for Digole serial/I2C/SPI displays and backpacks.
 paragraph=A fork of the original library by Digole, with updated coding style and some efficiency improvements.
+category=Display
 url=http://github.com/spapadim/Digole
 architectures=avr,arm,esp8266


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library Digole is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format