### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,21 +5,21 @@
 ###########################################
 # Datatypes (KEYWORD1)
 ###########################################
-DigoleSerial 	KEYWORD1
-DigoleI2C 	KEYWORD1
-DigoleSoftSPI 	KEYWORD1
-DigoleSPI 	KEYWORD1
+DigoleSerial	KEYWORD1
+DigoleI2C	KEYWORD1
+DigoleSoftSPI	KEYWORD1
+DigoleSPI	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-write	 	KEYWORD2
-begin	 	KEYWORD2
+write	KEYWORD2
+begin	KEYWORD2
 clearScreen	KEYWORD2
 setBacklight	KEYWORD2
 setContrast	KEYWORD2
 setRotation	KEYWORD2
-setFont		KEYWORD2
+setFont	KEYWORD2
 setColor	KEYWORD2
 setBackgroundColor	KEYWORD2
 setTextPosition	KEYWORD2
@@ -45,21 +45,21 @@ readTouchscreen	KEYWORD2
 ###########################################
 # Constants (LITERAL1)
 ###########################################
-ROT0		LITERAL1
-ROT90		LITERAL1
-ROT180		LITERAL1
-ROT270		LITERAL1
+ROT0	LITERAL1
+ROT90	LITERAL1
+ROT180	LITERAL1
+ROT270	LITERAL1
 BITMAP_8	LITERAL1
 BITMAP_256	LITERAL1
 BITMAP_262K	LITERAL1
 CHARACTER	LITERAL1
-PIXEL		LITERAL1
+PIXEL	LITERAL1
 TOUCH_DOWN	LITERAL1
 TOUCH_DOWN_NONBLOCKING	LITERAL1
 TOUCH_UP	LITERAL1
 MODE_COPY	LITERAL1
 MODE_NOT	LITERAL1
-MODE_OR		LITERAL1
+MODE_OR	LITERAL1
 MODE_XOR	LITERAL1
 MODE_AND	LITERAL1
 CHIP_ST7920	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords